### PR TITLE
Update path to modbus.h

### DIFF
--- a/l510_vfd.c
+++ b/l510_vfd.c
@@ -36,7 +36,7 @@
 #include <getopt.h>
 #include "rtapi.h"
 #include "hal.h"
-#include <modbus.h>
+#include <modbus/modbus.h>
 #include <math.h>
 
 /* Read Registers:


### PR DESCRIPTION
modbus.h has moved to a modbus subdirectory of /usr/include